### PR TITLE
Run docker with system cgroup driver

### DIFF
--- a/install-k8s.sh
+++ b/install-k8s.sh
@@ -18,3 +18,9 @@ EOF
 sudo apt-get update
 sudo apt-get install -y kubelet kubeadm kubectl wireguard
 sudo apt-mark hold kubelet kubeadm kubectl
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+  "exec-opts": ["native.cgroupdriver=systemd"]
+}
+EOF
+sudo systemctl restart docker


### PR DESCRIPTION
It seems k8s requires using the systemd cgroup driver [1] and without
this kubelet will fail to start with:

    failed to run Kubelet: misconfiguration: kubelet cgroup driver: "systemd" is different from docker cgroup driver: "cgroupfs"

[1] https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/